### PR TITLE
Update README.md to reflect repository status as retired

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # nr-permitting-data-spec
- 
 
-[![Lifecycle:Maturing](https://img.shields.io/badge/Lifecycle-Maturing-007EC6)](<Redirect-URL>)
+[![Lifecycle:Retired](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 ---
+
 ## NR Permitting Data Specifications Repository
+
 ---
+
+_Note: This repository is archived and no longer actively maintained. It is retained for historical reference. Please visit the [Permitting Interoperability Exchange Specification](https://bcgov.github.io/nr-pies/) for the latest information on permitting data specifications._
+
 This repository contains common schemas related to permitting in the Natural Resources and includes other artifacts developed for permitting modernization initiative. Leveraging common schemas will enable consistency, cross sector governance, identify patterns and opportunities and allow reporting and analytics to feed into decision making.
 
 ## How to Contribute
@@ -18,7 +22,7 @@ Review the [Contributing Guidelines](CONTRIBUTING.md) and the [Contributor Coven
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at 
+    You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 


### PR DESCRIPTION
This pull request updates the `README.md` file to reflect the archival status of the repository and provide guidance for users seeking updated information. 

### Updates to repository status:

* Updated the lifecycle badge to "Retired" and linked to the appropriate documentation for lifecycle badges.
* Added a note indicating that the repository is archived, is no longer actively maintained, and is retained for historical reference. Users are directed to the [Permitting Interoperability Exchange Specification](https://bcgov.github.io/nr-pies/) for the latest information on permitting data specifications.